### PR TITLE
fix: ensure only untranslatable fields get ignored from serialization

### DIFF
--- a/src/classes/Lingohub/Content.php
+++ b/src/classes/Lingohub/Content.php
@@ -73,7 +73,7 @@ final class Content
             if (!isset($fields[$key])) {
                 continue;
             }
-            if (!$fields[$key]['translate']) {
+            if (!isset($fields[$key]['translate']) || !$fields[$key]['translate']) {
                 continue;
             }
 

--- a/src/classes/Lingohub/Content.php
+++ b/src/classes/Lingohub/Content.php
@@ -73,6 +73,7 @@ final class Content
             if (!isset($fields[$key])) {
                 continue;
             }
+
             if (!($fields[$key]['translate'] ?? true)) {
                 continue;
             }

--- a/src/classes/Lingohub/Content.php
+++ b/src/classes/Lingohub/Content.php
@@ -73,7 +73,7 @@ final class Content
             if (!isset($fields[$key])) {
                 continue;
             }
-            if (!isset($fields[$key]['translate']) || !$fields[$key]['translate']) {
+            if (!($fields[$key]['translate'] ?? true)) {
                 continue;
             }
 


### PR DESCRIPTION
Added missing isset check that in some cases otherwise results in a crash.